### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=FaBo<info@fabo.io>
 maintainer=Akira Sasaki<akira@fabo.io>
 sentence=A library for FaBo Motor.
 paragraph=DRV8830 is motor driver.
-category=MOTOR
+category=Device Control
 url=https://github.com/FaBoPlatform/FaBoMotor-DRV8830-Library
 architectures=avr,esp32


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'MOTOR' in library FaBo Motor DRV8830 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format